### PR TITLE
tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,29 +17,5 @@ target_include_directories(app PRIVATE src)
 target_sources(app PRIVATE src/uut/uut.c)
 target_include_directories(app PRIVATE ./src/uut)
 
-if (NOT CONFIG_TEST)
-
 # add main
 target_sources(app PRIVATE src/main.c)
-
-else()
-
-# generate runner for the test
-test_runner_generate(tests/example_test.c)
-target_include_directories(app PRIVATE ./tests)
-
-# create mock for foo module. Add header to relative path 'foo'. That is to
-# allow including header using <foo/foo.h>
-cmock_handle(src/foo/foo.h foo)
-
-# add test file
-target_sources(app PRIVATE tests/example_test.c)
-target_include_directories(app PRIVATE .)
-target_include_directories(app PRIVATE src/foo)
-
-# Preinclude file to the module under test to redefine IS_ENABLED() macro
-# which is used in the module.
-set_property(SOURCE src/uut/uut.c PROPERTY COMPILE_FLAGS
-	"-include tests/example_test.h")
-
-endif()

--- a/src/foo/foo.c
+++ b/src/foo/foo.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <foo/foo.h>
+#include "foo.h"
 
 int foo_init(void *handle)
 {

--- a/src/uut/uut.c
+++ b/src/uut/uut.c
@@ -3,10 +3,11 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <uut.h>
-#include <foo/foo.h>
 #include <zephyr/sys/util.h>
 #include <stddef.h>
+
+#include "foo/foo.h"
+#include "uut.h"
 
 int uut_init(void *handle)
 {

--- a/test_run.sh
+++ b/test_run.sh
@@ -1,3 +1,6 @@
-#!/bin/sh
+#!/bin/sh -eu
 
-west build -b native_posix_64 -t run -d ./build-tests $@ -- -DCACHED_CONF_FILE=./tests/prj_test.conf
+cd tests
+cd uut; west build -b native_sim_64 -t run  $@; cd ..
+cd foo; west build -b native_sim_64 -t run  $@; cd ..
+cd ..

--- a/testcase.yaml
+++ b/testcase.yaml
@@ -1,7 +1,0 @@
-tests:
-  unity.example_test:
-    tags: example
-    integration_platforms:
-      - native_posix_64
-    platform_allow:
-      - native_posix_64

--- a/tests/foo/CMakeLists.txt
+++ b/tests/foo/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(foo_test)
+
+# Generate runner for the test
+test_runner_generate(src/foo_test.c)
+
+set(ROOTDIR ../..)
+
+# Include target sources
+target_sources(app PRIVATE ${ROOTDIR}/src/foo/foo.c)
+target_include_directories(app PRIVATE ${ROOTDIR}/src/foo)
+
+# add test file
+target_sources(app PRIVATE src/foo_test.c)
+
+target_include_directories(app PRIVATE .)
+target_include_directories(app PRIVATE src)

--- a/tests/foo/Kconfig
+++ b/tests/foo/Kconfig
@@ -1,0 +1,1 @@
+source "Kconfig.zephyr"

--- a/tests/foo/prj.conf
+++ b/tests/foo/prj.conf
@@ -4,6 +4,3 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 CONFIG_UNITY=y
-CONFIG_RING_BUFFER=y
-
-CONFIG_TEST=y

--- a/tests/foo/src/foo_test.c
+++ b/tests/foo/src/foo_test.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <unity.h>
+#include <stdbool.h>
+
+#include "foo.h"
+
+void test_foo_init(void)
+{
+	int err;
+
+	err = foo_init(NULL);
+	TEST_ASSERT_EQUAL(0, err);
+}
+
+void test_foo_execute(void)
+{
+	int err;
+
+	err = foo_execute();
+	TEST_ASSERT_EQUAL(0, err);
+}
+
+/* It is required to be added to each test. That is because unity's
+ * main may return nonzero, while zephyr's main currently must
+ * return 0 in all cases (other values are reserved).
+ */
+extern int unity_main(void);
+
+int main(void)
+{
+	(void)unity_main();
+
+	return 0;
+}

--- a/tests/foo/testcase.yaml
+++ b/tests/foo/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  unity.foo_test:
+    tags: foo_test
+    integration_platforms:
+      - native_sim_64
+    platform_allow:
+      - native_sim_64

--- a/tests/uut/CMakeLists.txt
+++ b/tests/uut/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(uut_test)
+
+# Generate runner for the test
+test_runner_generate(src/uut_test.c)
+
+set(ROOTDIR ../..)
+
+# Create mocks
+cmock_handle(${ROOTDIR}/src/foo/foo.h)
+target_include_directories(app PRIVATE ${ROOTDIR}/src)
+target_include_directories(app PRIVATE ${ROOTDIR}/src/foo)
+
+# Include target sources
+target_sources(app PRIVATE ${ROOTDIR}/src/uut/uut.c)
+target_include_directories(app PRIVATE ${ROOTDIR}/src/uut)
+
+# add test file
+target_sources(app PRIVATE src/uut_test.c)
+
+target_include_directories(app PRIVATE .)
+target_include_directories(app PRIVATE src)
+
+# Preinclude file to the module under test to redefine IS_ENABLED() macro
+# which is used in the module.
+set_property(SOURCE ${ROOTDIR}/src/uut/uut.c PROPERTY COMPILE_FLAGS
+	"-include src/uut_test.h")

--- a/tests/uut/Kconfig
+++ b/tests/uut/Kconfig
@@ -1,0 +1,1 @@
+source "Kconfig.zephyr"

--- a/tests/uut/prj.conf
+++ b/tests/uut/prj.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_UNITY=y

--- a/tests/uut/src/uut_test.c
+++ b/tests/uut/src/uut_test.c
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #include <unity.h>
-#include <uut.h>
 #include <stdbool.h>
-#include "foo/cmock_foo.h"
+
+#include "uut.h"
+#include "cmock_foo.h"
 
 bool runtime_CONFIG_UUT_PARAM_CHECK;
 

--- a/tests/uut/src/uut_test.h
+++ b/tests/uut/src/uut_test.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef EXAMPLE_TEST_H_
-#define EXAMPLE_TEST_H_
+#ifndef UUT_TEST_H_
+#define UUT_TEST_H_
 
 #include <zephyr/sys/util.h>
 #include <stdbool.h>
@@ -24,4 +24,4 @@
 
 extern bool runtime_CONFIG_UUT_PARAM_CHECK;
 
-#endif /* EXAMPLE_TEST_H_ */
+#endif /* UUT_TEST_H_ */

--- a/tests/uut/testcase.yaml
+++ b/tests/uut/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  unity.uut_test:
+    tags: uut_test
+    integration_platforms:
+      - native_sim_64
+    platform_allow:
+      - native_sim_64


### PR DESCRIPTION
asset_tracker_v2 を参考に `tests/` にテストコードを移動。
ついでに `foo.c` のテストも追加。

https://github.com/nrfconnect/sdk-nrf/tree/main/applications/asset_tracker_v2/tests/ui_module
